### PR TITLE
Fix the workspace page

### DIFF
--- a/apps/sim/app/workspace/[workspaceId]/page.tsx
+++ b/apps/sim/app/workspace/[workspaceId]/page.tsx
@@ -1,10 +1,10 @@
 import { redirect } from 'next/navigation'
 
-export default async function WorkspacePage({
+export default function WorkspacePage({
   params,
 }: {
-  params: Promise<{ workspaceId: string }>
+  params: { workspaceId: string }
 }) {
-  const { workspaceId } = await params
+  const { workspaceId } = params
   redirect(`/workspace/${workspaceId}/w`)
 }


### PR DESCRIPTION
## Summary
This PR fixes a bug on the `/workspace/[workspaceId]` page where the `params` object was incorrectly typed as a `Promise`. This incorrect typing prevented the page from correctly redirecting to `/workspace/[workspaceId]/w`. The fix updates the `params` type to a plain object and removes the unnecessary `await`.

Fixes #

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The change was verified by running the `apps/sim` type checker.
To test, navigate to `/workspace/<id>` (e.g., `/workspace/123`) and confirm that it correctly redirects to `/workspace/<id>/w`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-reviewed my changes
- [x] Tests added/updated and passing (type check)
- [x] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
<a href="https://cursor.com/background-agent?bcId=bc-a9f9e780-66be-4905-8630-9070e0da5cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9f9e780-66be-4905-8630-9070e0da5cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

