### PR TITLE
Debug and fix workspace page loading

### DIFF
--- a/apps/sim/app/layout.tsx
+++ b/apps/sim/app/layout.tsx
@@ -29,7 +29,8 @@ const BROWSER_EXTENSION_ATTRIBUTES = [
 if (typeof window !== 'undefined') {
   const originalError = console.error
   console.error = (...args) => {
-    if (args[0].includes('Hydration')) {
+    const firstArg = args[0]
+    if (typeof firstArg === 'string' && firstArg.includes('Hydration')) {
       const isExtensionError = BROWSER_EXTENSION_ATTRIBUTES.some((attr) =>
         args.some((arg) => typeof arg === 'string' && arg.includes(attr))
       )


### PR DESCRIPTION
## Summary
This PR fixes a potential runtime crash in the hydration error interception logic within `apps/sim/app/layout.tsx`. Previously, `console.error` calls with non-string arguments could cause the application to fail, preventing the workspace page from loading. This change adds a type guard to ensure the first argument is a string before attempting to check for 'Hydration' errors, improving the robustness of the error handling.

Fixes #N/A

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: ___________

## Testing
The fix was verified by starting the dev server and confirming that the `/workspace` route correctly redirects to `/login` when unauthenticated, and the `/login` page loads successfully (HTTP 200). This addresses the underlying issue that could prevent the workspace from rendering.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my changes
- [ ] Tests added/updated and passing
- [ ] No new warnings introduced
- [ ] I confirm that I have read and agree to the terms outlined in the [Contributor License Agreement (CLA)](./CONTRIBUTING.md#contributor-license-agreement-cla)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to help explain your changes -->
<!-- For UI changes, before/after screenshots are especially helpful -->

---
<a href="https://cursor.com/background-agent?bcId=bc-da2b7389-8337-4718-9f64-2ca653523369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da2b7389-8337-4718-9f64-2ca653523369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

